### PR TITLE
Update screenshot file prefix

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -11,7 +11,7 @@ from PySide6.QtCore import QRect, Qt, QStandardPaths  # QStandardPaths itt nem k
 # A QApplication példányt a main.py hozza létre.
 # Ennek a modulnak arra kell támaszkodnia.
 
-def take_screenshot(save_directory, filename_prefix="screenshot", area=None, add_timestamp=False):
+def take_screenshot(save_directory, filename_prefix="Screenshot", area=None, add_timestamp=False):
     """
     Képernyőképet készít a megadott területről vagy a teljes elsődleges képernyőről.
 
@@ -68,9 +68,11 @@ def take_screenshot(save_directory, filename_prefix="screenshot", area=None, add
             painter.end()
 
         # --- MÓDOSÍTOTT FÁJLNÉV FORMÁTUM ---
-        # Kért formátum: évszám-hónap-nap-óra-perc
-        # Hozzáadva a másodperc is az egyediség és a felülírás elkerülése végett.
-        timestamp_for_filename = datetime.now().strftime("%Y-%m-%d-%H-%M-%S") 
+        # Kért formátum: Screenshot_YYYY_MM_DD_HH-MM:SS
+        # Az aláhúzások és kötőjelek/kettespontok a példában megadott elnevezési
+        # szabályt követik. A másodpercek továbbra is szerepelnek a felülírás
+        # elkerülése érdekében.
+        timestamp_for_filename = datetime.now().strftime("%Y_%m_%d_%H-%M:%S")
         
         filename = f"{filename_prefix}_{timestamp_for_filename}.png"
         # Ha a prefixet el szeretnéd hagyni, akkor:
@@ -106,7 +108,7 @@ if __name__ == "__main__":
     try:
         # Csak a fájlnév generálási logika tesztelése (nem készít képet)
         prefix_test = "test_prefix"
-        ts_test = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        ts_test = datetime.now().strftime("%Y_%m_%d_%H-%M:%S")
         fn_test = f"{prefix_test}_{ts_test}.png"
         print(f"\nPélda generált fájlnév ({prefix_test} prefixszel): {fn_test}")
 


### PR DESCRIPTION
### **User description**
## Summary
- default to `Screenshot` as the prefix when saving screenshots

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842b8ec6ce88327a19b16bb55915350


___

### **PR Type**
Enhancement


___

### **Description**
- Change default screenshot filename prefix to `Screenshot`

- Update filename timestamp format to use underscores and colons

- Adjust test block to reflect new filename format


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Update screenshot filename prefix and timestamp formatting</code></dd></summary>
<hr>

core/screenshot_taker.py

<li>Changed default filename prefix from <code>screenshot</code> to <code>Screenshot</code><br> <li> Updated timestamp format in filenames to use underscores and colons<br> <li> Modified test block to match new filename format


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/6/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>