### PR TITLE
Fix screenshot naming and corrupted output

### DIFF
--- a/background_monitor.py
+++ b/background_monitor.py
@@ -43,7 +43,7 @@ def main():
                     if mode == "custom" and custom_area:
                         rect = QRect(custom_area.get("x", 0), custom_area.get("y", 0),
                                      custom_area.get("width", 0), custom_area.get("height", 0))
-                    take_screenshot(save_path, "scheduled_screenshot", rect, True)
+                    take_screenshot(save_path, "Screenshot", rect, True)
                     executed.add(key)
             time.sleep(60)
     except KeyboardInterrupt:

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -107,7 +107,7 @@ class Scheduler:
                 self.scheduler.add_job(
                     take_screenshot,
                     trigger=trigger,
-                    args=[save_path, "scheduled_screenshot", area_arg, True],  # area_arg itt QRect vagy None
+                    args=[save_path, "Screenshot", area_arg, True],  # area_arg itt QRect vagy None
                     id=job_id,
                     name=f"Screenshot at {time_str} on {days_str}",
                     replace_existing=True  # Felülírja, ha véletlenül létezne már ilyen ID

--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -18,7 +18,7 @@ def take_screenshot(save_directory, filename_prefix="Screenshot", area=None, add
 
     Args:
         save_directory (str): A könyvtár, ahova a képet menteni kell.
-        filename_prefix (str, optional): A fájlnév előtagja. Alapértelmezett: "screenshot".
+        filename_prefix (str, optional): A fájlnév előtagja. Alapértelmezett: "Screenshot".
         area (QRect, optional): A rögzítendő terület. Ha None, a teljes elsődleges
                                 képernyőt rögzíti.
         add_timestamp (bool, optional): Ha True, a kész kép jobb alsó sarkára
@@ -69,11 +69,10 @@ def take_screenshot(save_directory, filename_prefix="Screenshot", area=None, add
             painter.end()
 
         # --- MÓDOSÍTOTT FÁJLNÉV FORMÁTUM ---
-        # Kért formátum: Screenshot_YYYY_MM_DD_HH-MM:SS
-        # Az aláhúzások és kötőjelek/kettespontok a példában megadott elnevezési
-        # szabályt követik. A másodpercek továbbra is szerepelnek a felülírás
-        # elkerülése érdekében.
-        timestamp_for_filename = datetime.now().strftime("%Y_%m_%d_%H-%M:%S")
+        # Kért formátum: Screenshot_YYYY_MM_DD_HH-MM-SS
+        # A kettőspont használata Windows rendszeren problémát okozhat, ezért
+        # a másodperceket is kötőjellel választjuk el.
+        timestamp_for_filename = datetime.now().strftime("%Y_%m_%d_%H-%M-%S")
         
         filename = f"{filename_prefix}_{timestamp_for_filename}.png"
         # Ha a prefixet el szeretnéd hagyni, akkor:


### PR DESCRIPTION
## Summary
- remove `scheduled_screenshot` prefix when scheduler or monitor saves screenshots
- avoid colon in screenshot file names for better cross‑platform support
- update screenshot docstring

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842bbf80dc08327aa3353f5bd4118ba