### PR TITLE
Add timestamp toggle and adjust overlay

### DIFF
--- a/background_monitor.py
+++ b/background_monitor.py
@@ -29,6 +29,7 @@ def main():
     mode = settings.get("screenshot_mode", "fullscreen")
     custom_area = settings.get("custom_area")
     schedules = settings.get("schedules", [])
+    include_timestamp = settings.get("include_timestamp", True)
     executed = set()
     print("Idozito monitor elindult. Ctrl+C a leallitasahoz.")
     try:
@@ -43,7 +44,7 @@ def main():
                     if mode == "custom" and custom_area:
                         rect = QRect(custom_area.get("x", 0), custom_area.get("y", 0),
                                      custom_area.get("width", 0), custom_area.get("height", 0))
-                    take_screenshot(save_path, "Screenshot", rect, True)
+                    take_screenshot(save_path, "Screenshot", rect, include_timestamp)
                     executed.add(key)
             time.sleep(60)
     except KeyboardInterrupt:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -87,7 +87,8 @@ class ConfigManager:
             "save_path": default_screenshot_save_path,
             "screenshot_mode": "fullscreen",
             "custom_area": {"x": 0, "y": 0, "width": 100, "height": 100},
-            "schedules": []
+            "schedules": [],
+            "include_timestamp": True,
         }
 
     def load_settings(self):

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -62,9 +62,10 @@ class Scheduler:
             # Folytatjuk az újak hozzáadásával
 
         schedules = self.current_settings.get("schedules", [])
-        save_path = self.current_settings.get("save_path", ".") # Alapértelmezett: aktuális mappa
+        save_path = self.current_settings.get("save_path", ".")
         mode = self.current_settings.get("screenshot_mode", "fullscreen")
         custom_area_dict = self.current_settings.get("custom_area", None)
+        include_timestamp = self.current_settings.get("include_timestamp", True)
 
         logger.info(f"Feladatok ütemezése {len(schedules)} szabály alapján. Mentési hely: {save_path}, Mód: {mode}")
 
@@ -107,10 +108,10 @@ class Scheduler:
                 self.scheduler.add_job(
                     take_screenshot,
                     trigger=trigger,
-                    args=[save_path, "Screenshot", area_arg, True],  # area_arg itt QRect vagy None
+                    args=[save_path, "Screenshot", area_arg, include_timestamp],
                     id=job_id,
                     name=f"Screenshot at {time_str} on {days_str}",
-                    replace_existing=True  # Felülírja, ha véletlenül létezne már ilyen ID
+                    replace_existing=True,
                 )
                 logger.info(f"Feladat hozzáadva (ID: {job_id}): Idő={time_str}, Napok={days_str}, Terület={area_arg if area_arg else 'Fullscreen'}")
 

--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -63,9 +63,11 @@ def take_screenshot(save_directory, filename_prefix="Screenshot", area=None, add
             painter.setPen(Qt.GlobalColor.white)
             painter.setFont(QFont("Arial", 14))
             timestamp_text = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            painter.drawText(pixmap.rect().adjusted(10, 10, -10, -10),
-                             Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignBottom,
-                             timestamp_text)
+            painter.drawText(
+                pixmap.rect().adjusted(10, 10, -10, -10),
+                Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop,
+                timestamp_text,
+            )
             painter.end()
 
         # --- MÓDOSÍTOTT FÁJLNÉV FORMÁTUM ---


### PR DESCRIPTION
### **User description**
## Summary
- display the timestamp text in the screenshot's top-left corner
- allow disabling the timestamp via new checkbox under the autostart option
- store the timestamp preference in the configuration and pass it to the scheduler

## Testing
- `python -m py_compile background_monitor.py core/config_manager.py core/scheduler.py core/screenshot_taker.py gui/main_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bda4f0f48327b3ef7a03d3defa30


___

### **PR Type**
Enhancement


___

### **Description**
- Added option to toggle timestamp overlay on screenshots
  - New checkbox in GUI for enabling/disabling timestamp
  - Timestamp preference saved in configuration
  - Timestamp option passed to scheduler and screenshot taker

- Moved timestamp overlay to top-left corner of screenshots


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>background_monitor.py</strong><dd><code>Pass timestamp overlay setting to screenshot taker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

background_monitor.py

<li>Loaded <code>include_timestamp</code> from settings.<br> <li> Passed <code>include_timestamp</code> to <code>take_screenshot</code> instead of hardcoded True.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/8/files#diff-6ea3b234114fbc3391bd4a3b63cd01e924474b2c6feee2cf180e8b55ac5cb1ca">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config_manager.py</strong><dd><code>Add timestamp overlay preference to default settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/config_manager.py

- Added `include_timestamp` (default True) to default settings.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/8/files#diff-b922428b6ae5ece0d80773f599f75999b3d61747937aef52311160a3d69d6ae8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scheduler.py</strong><dd><code>Pass timestamp overlay setting to scheduled jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/scheduler.py

<li>Loaded <code>include_timestamp</code> from settings.<br> <li> Passed <code>include_timestamp</code> to scheduled screenshot jobs.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/8/files#diff-3732d9df85981e6c160f0bccd47824125ad2f611429bb44682029e2b66e5f8cb">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Move timestamp overlay to top-left in screenshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/screenshot_taker.py

<li>Changed timestamp overlay position to top-left corner.<br> <li> Updated QPainter drawText alignment for timestamp.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/8/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main_window.py</strong><dd><code>Add and wire up timestamp overlay toggle in GUI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/main_window.py

<li>Added checkbox to enable/disable timestamp overlay in UI.<br> <li> Connected checkbox state to settings and save logic.<br> <li> Updated UI and settings save/load to handle timestamp preference.


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/8/files#diff-c06f3750551501fc07ce1aff486fd8b3c26780da89363df5c05d118953ee8659">+30/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>