### PR TITLE
Add timestamp position options

### DIFF
--- a/background_monitor.py
+++ b/background_monitor.py
@@ -30,6 +30,7 @@ def main():
     custom_area = settings.get("custom_area")
     schedules = settings.get("schedules", [])
     include_timestamp = settings.get("include_timestamp", True)
+    timestamp_position = settings.get("timestamp_position", "top-left")
     executed = set()
     print("Idozito monitor elindult. Ctrl+C a leallitasahoz.")
     try:
@@ -44,7 +45,7 @@ def main():
                     if mode == "custom" and custom_area:
                         rect = QRect(custom_area.get("x", 0), custom_area.get("y", 0),
                                      custom_area.get("width", 0), custom_area.get("height", 0))
-                    take_screenshot(save_path, "Screenshot", rect, include_timestamp)
+                    take_screenshot(save_path, "Screenshot", rect, include_timestamp, timestamp_position)
                     executed.add(key)
             time.sleep(60)
     except KeyboardInterrupt:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -89,6 +89,7 @@ class ConfigManager:
             "custom_area": {"x": 0, "y": 0, "width": 100, "height": 100},
             "schedules": [],
             "include_timestamp": True,
+            "timestamp_position": "top-left",
         }
 
     def load_settings(self):

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -66,6 +66,7 @@ class Scheduler:
         mode = self.current_settings.get("screenshot_mode", "fullscreen")
         custom_area_dict = self.current_settings.get("custom_area", None)
         include_timestamp = self.current_settings.get("include_timestamp", True)
+        timestamp_position = self.current_settings.get("timestamp_position", "top-left")
 
         logger.info(f"Feladatok ütemezése {len(schedules)} szabály alapján. Mentési hely: {save_path}, Mód: {mode}")
 
@@ -108,7 +109,7 @@ class Scheduler:
                 self.scheduler.add_job(
                     take_screenshot,
                     trigger=trigger,
-                    args=[save_path, "Screenshot", area_arg, include_timestamp],
+                    args=[save_path, "Screenshot", area_arg, include_timestamp, timestamp_position],
                     id=job_id,
                     name=f"Screenshot at {time_str} on {days_str}",
                     replace_existing=True,

--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -12,7 +12,7 @@ from PySide6.QtCore import QRect, Qt, QStandardPaths
 # A QApplication példányt a main.py hozza létre.
 # Ennek a modulnak arra kell támaszkodnia.
 
-def take_screenshot(save_directory, filename_prefix="Screenshot", area=None, add_timestamp=False):
+def take_screenshot(save_directory, filename_prefix="Screenshot", area=None, add_timestamp=False, timestamp_position="top-left"):
     """
     Képernyőképet készít a megadott területről vagy a teljes elsődleges képernyőről.
 
@@ -21,8 +21,9 @@ def take_screenshot(save_directory, filename_prefix="Screenshot", area=None, add
         filename_prefix (str, optional): A fájlnév előtagja. Alapértelmezett: "Screenshot".
         area (QRect, optional): A rögzítendő terület. Ha None, a teljes elsődleges
                                 képernyőt rögzíti.
-        add_timestamp (bool, optional): Ha True, a kész kép jobb alsó sarkára
-                                ráírja az aktuális dátumot és időt.
+        add_timestamp (bool, optional): Ha True, a képre ráírja az aktuális dátumot.
+        timestamp_position (str, optional): A felirat helye ('top-left', 'top-right',
+                                'bottom-left', 'bottom-right').
 
     Returns:
         str | None: A mentett kép teljes elérési útja siker esetén, None hiba esetén.
@@ -63,9 +64,16 @@ def take_screenshot(save_directory, filename_prefix="Screenshot", area=None, add
             painter.setPen(Qt.GlobalColor.white)
             painter.setFont(QFont("Arial", 14))
             timestamp_text = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            alignment = Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop
+            if timestamp_position == "top-right":
+                alignment = Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignTop
+            elif timestamp_position == "bottom-left":
+                alignment = Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignBottom
+            elif timestamp_position == "bottom-right":
+                alignment = Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignBottom
             painter.drawText(
                 pixmap.rect().adjusted(10, 10, -10, -10),
-                Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop,
+                alignment,
                 timestamp_text,
             )
             painter.end()

--- a/gui/timestamp_position_widget.py
+++ b/gui/timestamp_position_widget.py
@@ -1,0 +1,91 @@
+# gui/timestamp_position_widget.py
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QGroupBox,
+    QCheckBox,
+    QGridLayout,
+    QRadioButton
+)
+from PySide6.QtCore import Signal, Slot
+
+class TimestampPositionWidget(QWidget):
+    """Widget a dátum megjelenítésének pozíciójához és engedélyezéséhez."""
+
+    position_changed = Signal(str)
+    include_changed = Signal(bool)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        group_box = QGroupBox("Dátum beállítások")
+        main_layout.addWidget(group_box)
+
+        group_layout = QVBoxLayout(group_box)
+
+        self.include_checkbox = QCheckBox("Dátum kiírása")
+        group_layout.addWidget(self.include_checkbox)
+
+        grid = QGridLayout()
+        self.rb_tl = QRadioButton("Bal felső")
+        self.rb_tr = QRadioButton("Jobb felső")
+        self.rb_bl = QRadioButton("Bal alsó")
+        self.rb_br = QRadioButton("Jobb alsó")
+        grid.addWidget(self.rb_tl, 0, 0)
+        grid.addWidget(self.rb_tr, 0, 1)
+        grid.addWidget(self.rb_bl, 1, 0)
+        grid.addWidget(self.rb_br, 1, 1)
+        group_layout.addLayout(grid)
+
+        self.rb_tl.setChecked(True)
+
+        self.include_checkbox.toggled.connect(self.include_changed)
+        for rb in (self.rb_tl, self.rb_tr, self.rb_bl, self.rb_br):
+            rb.toggled.connect(self._on_position_toggled)
+
+    @Slot(bool)
+    def _on_position_toggled(self, checked):
+        if not checked:
+            return
+        mapping = {
+            self.rb_tl: "top-left",
+            self.rb_tr: "top-right",
+            self.rb_bl: "bottom-left",
+            self.rb_br: "bottom-right",
+        }
+        self.position_changed.emit(mapping[self.sender()])
+
+    def get_settings(self):
+        include = self.include_checkbox.isChecked()
+        if self.rb_tr.isChecked():
+            pos = "top-right"
+        elif self.rb_bl.isChecked():
+            pos = "bottom-left"
+        elif self.rb_br.isChecked():
+            pos = "bottom-right"
+        else:
+            pos = "top-left"
+        return include, pos
+
+    def set_settings(self, include, position):
+        self.include_checkbox.blockSignals(True)
+        self.include_checkbox.setChecked(include)
+        self.include_checkbox.blockSignals(False)
+
+        mapping = {
+            "top-left": self.rb_tl,
+            "top-right": self.rb_tr,
+            "bottom-left": self.rb_bl,
+            "bottom-right": self.rb_br,
+        }
+        rb = mapping.get(position, self.rb_tl)
+        for r in mapping.values():
+            r.blockSignals(True)
+        rb.setChecked(True)
+        for r in mapping.values():
+            r.blockSignals(False)
+


### PR DESCRIPTION
## Summary
- rename window title to FOTO-Apparátus and update tray texts
- add TimestampPositionWidget for choosing timestamp corner
- store timestamp position in config and pass to screenshot taker
- allow scheduler and background monitor to use new setting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842c0b379608327bc2533f0c3ff9950