### PR TITLE
Add window selection option

### DIFF
--- a/background_monitor.py
+++ b/background_monitor.py
@@ -45,7 +45,7 @@ def main():
                     if mode == "custom" and custom_area:
                         rect = QRect(custom_area.get("x", 0), custom_area.get("y", 0),
                                      custom_area.get("width", 0), custom_area.get("height", 0))
-                    take_screenshot(save_path, "Kép", rect, include_timestamp, timestamp_position)
+                    take_screenshot(save_path, "Kép", rect, include_timestamp, timestamp_position, settings.get("target_window", ""))
                     executed.add(key)
             time.sleep(60)
     except KeyboardInterrupt:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -88,6 +88,7 @@ class ConfigManager:
             "screenshot_mode": "fullscreen",
             "custom_area": {"x": 0, "y": 0, "width": 100, "height": 100},
             "schedules": [],
+            "target_window": "",
             "include_timestamp": True,
             "timestamp_position": "top-left",
         }

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -65,6 +65,7 @@ class Scheduler:
         save_path = self.current_settings.get("save_path", ".")
         mode = self.current_settings.get("screenshot_mode", "fullscreen")
         custom_area_dict = self.current_settings.get("custom_area", None)
+        target_window = self.current_settings.get("target_window", "")
         include_timestamp = self.current_settings.get("include_timestamp", True)
         timestamp_position = self.current_settings.get("timestamp_position", "top-left")
 
@@ -109,12 +110,14 @@ class Scheduler:
                 self.scheduler.add_job(
                     take_screenshot,
                     trigger=trigger,
-                    args=[save_path, "Kép", area_arg, include_timestamp, timestamp_position],
+                    args=[save_path, "Kép", area_arg, include_timestamp, timestamp_position, target_window],
                     id=job_id,
                     name=f"Kép at {time_str} on {days_str}",
                     replace_existing=True,
                 )
-                logger.info(f"Feladat hozzáadva (ID: {job_id}): Idő={time_str}, Napok={days_str}, Terület={area_arg if area_arg else 'Fullscreen'}")
+                logger.info(
+                    f"Feladat hozzáadva (ID: {job_id}): Idő={time_str}, Napok={days_str}, Terület={area_arg if area_arg else 'Fullscreen'}, Ablak='{target_window}'"
+                )
 
             except (ValueError, KeyError, Exception) as e:
                 logger.error(f"Hiba az ütemezési szabály feldolgozása közben: {schedule_item} - Hiba: {e}")

--- a/gui/window_selector_widget.py
+++ b/gui/window_selector_widget.py
@@ -1,0 +1,87 @@
+# gui/window_selector_widget.py
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QGroupBox,
+    QComboBox,
+    QPushButton,
+    QLabel,
+)
+from PySide6.QtCore import Signal
+
+import platform
+
+try:
+    if platform.system() == "Windows":
+        import pygetwindow as gw
+    else:
+        gw = None
+except Exception:
+    gw = None
+
+class WindowSelectorWidget(QWidget):
+    """Widget a futó alkalmazások ablakainak kiválasztásához."""
+
+    selection_changed = Signal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        group_box = QGroupBox("Alkalmazás kiválasztása")
+        main_layout.addWidget(group_box)
+
+        group_layout = QVBoxLayout(group_box)
+
+        if gw is None:
+            self.info_label = QLabel("Nem támogatott rendszer")
+            group_layout.addWidget(self.info_label)
+            self.combo = None
+            return
+
+        combo_layout = QHBoxLayout()
+        self.combo = QComboBox()
+        self.refresh_button = QPushButton("Frissítés")
+        combo_layout.addWidget(self.combo)
+        combo_layout.addWidget(self.refresh_button)
+        group_layout.addLayout(combo_layout)
+
+        self.refresh_button.clicked.connect(self.refresh_list)
+        self.combo.currentTextChanged.connect(self._emit_change)
+
+        self.refresh_list()
+
+    def refresh_list(self):
+        if self.combo is None or gw is None:
+            return
+        self.combo.blockSignals(True)
+        self.combo.clear()
+        self.combo.addItem("")  # üres választás
+        try:
+            titles = [t for t in gw.getAllTitles() if t.strip()]
+            for title in titles:
+                self.combo.addItem(title)
+        except Exception:
+            pass
+        self.combo.blockSignals(False)
+
+    def _emit_change(self, text):
+        self.selection_changed.emit(text)
+
+    def get_selected_title(self):
+        if self.combo is None:
+            return ""
+        return self.combo.currentText()
+
+    def set_selected_title(self, title):
+        if self.combo is None:
+            return
+        index = self.combo.findText(title)
+        if index >= 0:
+            self.combo.setCurrentIndex(index)
+        else:
+            self.combo.setCurrentIndex(0)


### PR DESCRIPTION
## Summary
- add WindowSelectorWidget to choose a running app window
- save the selected window in config
- support capturing a chosen window in screenshot_taker
- pass window setting through scheduler and background monitor
- update main window to include widget and setting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685848e34a608327a841bf9cb17937e8