### PR TITLE
Add webcam photo capture mode

### DIFF
--- a/background_monitor.py
+++ b/background_monitor.py
@@ -27,6 +27,7 @@ def main():
     settings = cfg.load_settings()
     save_path = settings.get("save_path", ".")
     mode = settings.get("screenshot_mode", "fullscreen")
+    capture_type = settings.get("capture_type", "screenshot")
     custom_area = settings.get("custom_area")
     schedules = settings.get("schedules", [])
     include_timestamp = settings.get("include_timestamp", True)
@@ -43,9 +44,24 @@ def main():
                         continue
                     rect = None
                     if mode == "custom" and custom_area:
-                        rect = QRect(custom_area.get("x", 0), custom_area.get("y", 0),
-                                     custom_area.get("width", 0), custom_area.get("height", 0))
-                    take_screenshot(save_path, "Kép", rect, include_timestamp, timestamp_position, settings.get("target_window", ""))
+                        rect = QRect(
+                            custom_area.get("x", 0),
+                            custom_area.get("y", 0),
+                            custom_area.get("width", 0),
+                            custom_area.get("height", 0),
+                        )
+                    if capture_type == "photo":
+                        from core.photo_taker import take_photo
+                        take_photo(save_path, "Foto")
+                    else:
+                        take_screenshot(
+                            save_path,
+                            "Kép",
+                            rect,
+                            include_timestamp,
+                            timestamp_position,
+                            settings.get("target_window", ""),
+                        )
                     executed.add(key)
             time.sleep(60)
     except KeyboardInterrupt:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -85,6 +85,7 @@ class ConfigManager:
         return {
             # Ez most a Képek mappába mutat alapértelmezetten
             "save_path": default_screenshot_save_path,
+            "capture_type": "screenshot",
             "screenshot_mode": "fullscreen",
             "custom_area": {"x": 0, "y": 0, "width": 100, "height": 100},
             "schedules": [],

--- a/core/photo_taker.py
+++ b/core/photo_taker.py
@@ -1,0 +1,26 @@
+# core/photo_taker.py
+
+import os
+from datetime import datetime
+
+import cv2
+
+
+def take_photo(save_directory, filename_prefix="Foto"):
+    """Készít egy fényképet az alapértelmezett webkamerával."""
+    cap = cv2.VideoCapture(0)
+    success, frame = cap.read()
+    cap.release()
+    if not success:
+        print("HIBA: Nem sikerült képet készíteni a webkameráról.")
+        return None
+
+    os.makedirs(save_directory, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y_%m_%d_%H-%M")
+    filename = f"{filename_prefix}_{timestamp}.png"
+    save_path = os.path.join(save_directory, filename)
+    if cv2.imwrite(save_path, frame):
+        print(f"Fotó elmentve: {save_path}")
+        return save_path
+    print(f"HIBA: Nem sikerült elmenteni a fotót ide: {save_path}")
+    return None


### PR DESCRIPTION
## Summary
- implement `take_photo` using OpenCV
- add `capture_type` config option
- allow choosing screenshot or photo in the GUI
- schedule jobs according to capture type
- support background monitor for photo mode

## Testing
- `python -m py_compile core/photo_taker.py core/scheduler.py background_monitor.py gui/main_window.py core/config_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584d031dd48327846c938fa839c839