### PR TITLE
Update capture types to screenshot and program

### DIFF
--- a/background_monitor.py
+++ b/background_monitor.py
@@ -50,18 +50,14 @@ def main():
                             custom_area.get("width", 0),
                             custom_area.get("height", 0),
                         )
-                    if capture_type == "photo":
-                        from core.photo_taker import take_photo
-                        take_photo(save_path, "Foto")
-                    else:
-                        take_screenshot(
-                            save_path,
-                            "Kép",
-                            rect,
-                            include_timestamp,
-                            timestamp_position,
-                            settings.get("target_window", ""),
-                        )
+                    take_screenshot(
+                        save_path,
+                        "Kép",
+                        rect,
+                        include_timestamp,
+                        timestamp_position,
+                        settings.get("target_window", ""),
+                    )
                     executed.add(key)
             time.sleep(60)
     except KeyboardInterrupt:

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -110,25 +110,14 @@ class Scheduler:
 
                 # Feladat hozzáadása az ütemezőhöz
                 job_id = f"capture_job_{i}"
-                if capture_type == "photo":
-                    from .photo_taker import take_photo
-                    self.scheduler.add_job(
-                        take_photo,
-                        trigger=trigger,
-                        args=[save_path, "Foto"],
-                        id=job_id,
-                        name=f"Foto at {time_str} on {days_str}",
-                        replace_existing=True,
-                    )
-                else:
-                    self.scheduler.add_job(
-                        take_screenshot,
-                        trigger=trigger,
-                        args=[save_path, "Kép", area_arg, include_timestamp, timestamp_position, target_window],
-                        id=job_id,
-                        name=f"Kép at {time_str} on {days_str}",
-                        replace_existing=True,
-                    )
+                self.scheduler.add_job(
+                    take_screenshot,
+                    trigger=trigger,
+                    args=[save_path, "Kép", area_arg, include_timestamp, timestamp_position, target_window],
+                    id=job_id,
+                    name=f"Kép at {time_str} on {days_str}",
+                    replace_existing=True,
+                )
                 logger.info(
                     f"Feladat hozzáadva (ID: {job_id}): Idő={time_str}, Napok={days_str}, Típus={capture_type}"
                 )

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -238,9 +238,9 @@ class MainWindow(QMainWindow):
         self.capture_group = QGroupBox("Felvétel mód")
         capture_layout = QVBoxLayout(self.capture_group)
         self.radio_capture_screenshot = QRadioButton("Képernyőkép")
-        self.radio_capture_photo = QRadioButton("Fénykép")
+        self.radio_capture_program = QRadioButton("Programkép")
         capture_layout.addWidget(self.radio_capture_screenshot)
-        capture_layout.addWidget(self.radio_capture_photo)
+        capture_layout.addWidget(self.radio_capture_program)
         self.radio_capture_screenshot.setChecked(True)
         self.main_layout.addWidget(self.capture_group)
 
@@ -289,7 +289,7 @@ class MainWindow(QMainWindow):
         self.size_widget.mode_changed.connect(self._handle_mode_change)
         self.size_widget.select_area_requested.connect(self._start_area_selection)
         self.radio_capture_screenshot.toggled.connect(self._handle_capture_type_change)
-        self.radio_capture_photo.toggled.connect(self._handle_capture_type_change)
+        self.radio_capture_program.toggled.connect(self._handle_capture_type_change)
         if hasattr(self, 'window_selector'):
             self.window_selector.selection_changed.connect(lambda _: self._mark_dirty())
         self.timer_list.list_changed.connect(self._mark_dirty)
@@ -307,13 +307,16 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def _handle_capture_type_change(self):
-        capture_type = "photo" if self.radio_capture_photo.isChecked() else "screenshot"
-        widgets_enabled = capture_type == "screenshot"
-        self.size_widget.setEnabled(widgets_enabled)
-        self.window_selector.setEnabled(widgets_enabled)
+        capture_type = "program" if self.radio_capture_program.isChecked() else "screenshot"
+        size_enabled = capture_type == "screenshot"
+        window_enabled = capture_type == "program"
+        self.size_widget.setEnabled(size_enabled)
+        self.window_selector.setEnabled(window_enabled)
+        self.size_widget.setVisible(size_enabled)
+        self.window_selector.setVisible(window_enabled)
         color_inactive = "#555555"
-        self.size_widget.setStyleSheet("" if widgets_enabled else f"background-color: {color_inactive};")
-        self.window_selector.setStyleSheet("" if widgets_enabled else f"background-color: {color_inactive};")
+        self.size_widget.setStyleSheet("" if size_enabled else f"background-color: {color_inactive};")
+        self.window_selector.setStyleSheet("" if window_enabled else f"background-color: {color_inactive};")
         self.settings["capture_type"] = capture_type
         self._mark_dirty()
 
@@ -322,8 +325,8 @@ class MainWindow(QMainWindow):
         logger.info(self.settings)
         if not self.settings: logger.warning("Nincsenek beállítások a UI frissítéséhez."); return
         capture_loaded = self.settings.get("capture_type", "screenshot")
-        if capture_loaded == "photo":
-            self.radio_capture_photo.setChecked(True)
+        if capture_loaded == "program":
+            self.radio_capture_program.setChecked(True)
         else:
             self.radio_capture_screenshot.setChecked(True)
         self._handle_capture_type_change()
@@ -458,7 +461,7 @@ class MainWindow(QMainWindow):
 
         new_settings = {
             "save_path": save_path,
-            "capture_type": "photo" if self.radio_capture_photo.isChecked() else "screenshot",
+            "capture_type": "program" if self.radio_capture_program.isChecked() else "screenshot",
             "screenshot_mode": mode,
             "custom_area": custom_area_dict_to_save,
             "target_window": self.window_selector.get_selected_title() if hasattr(self, 'window_selector') else "",


### PR DESCRIPTION
## Summary
- rename the `Fénykép` capture option to `Programkép`
- show the screenshot size widget only in screenshot mode and the window selector only in program mode
- adjust saved `capture_type` values to `program`
- remove webcam capture logic from the scheduler and background monitor

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685850d68e2c8327ac2f20301364ec4f