### PR TITLE
Fix window capture with PrintWindow

### DIFF
--- a/background_monitor.py
+++ b/background_monitor.py
@@ -57,6 +57,7 @@ def main():
                         include_timestamp,
                         timestamp_position,
                         settings.get("target_window", ""),
+                        capture_type,
                     )
                     executed.add(key)
             time.sleep(60)


### PR DESCRIPTION
## Summary
- rewrite screenshot capturing logic to use Pillow and PrintWindow
- return Pillow image object from `take_screenshot`
- support capture type argument and use PrintWindow for program capture
- update background monitor to pass capture type

## Testing
- `python -m py_compile core/screenshot_taker.py background_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_685857dde4fc8327a865fe05f65c01c1