### PR TITLE
Fix dependency check for GUI modules

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+# FOTOapparatus package

--- a/main.py
+++ b/main.py
@@ -2,12 +2,21 @@
 
 import sys
 import os
-from PySide6.QtCore import QCoreApplication
-from PySide6.QtWidgets import QApplication
-# --- ÚJ IMPORT ---
-from PySide6.QtNetwork import QLocalSocket, QLocalServer
-# -----------------
 import logging
+
+try:
+    from PySide6.QtCore import QCoreApplication
+    from PySide6.QtWidgets import QApplication
+    # --- ÚJ IMPORT ---
+    from PySide6.QtNetwork import QLocalSocket, QLocalServer
+    # -----------------
+except ImportError as exc:  # pragma: no cover - dependency check
+    print(
+        "HIBA: A PySide6 csomag nem található. "
+        "Telepítse a következő paranccsal: pip install PySide6",
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from exc
 
 try:
     from gui.main_window import MainWindow


### PR DESCRIPTION
## Summary
- add package initializer
- add check in `main.py` to instruct installing PySide6 when missing

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68585d8748e08327a5afe96267ff3a03