### PR TITLE
Fix import path for main window

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -5,6 +5,12 @@ import os
 import traceback
 import logging
 
+# Ensure the core package is importable when running this file directly
+_current_dir = os.path.dirname(os.path.abspath(__file__))
+_parent_dir = os.path.dirname(_current_dir)
+if _parent_dir not in sys.path:
+    sys.path.insert(0, _parent_dir)
+
 try:
     from PySide6.QtCore import Slot, QRect, Qt, QCoreApplication, QStandardPaths, QRectF
     from PySide6.QtWidgets import (


### PR DESCRIPTION
## Summary
- ensure `core` package is on `sys.path` when launching `gui/main_window.py` directly

## Testing
- `python -m py_compile gui/main_window.py background_monitor.py core/config_manager.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68585ed7a0b083278de94f2bda5783c0