### PR TITLE
Fix text color in main window

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -113,7 +113,11 @@ class MainWindow(QMainWindow):
 
         central_widget = QWidget(self)
         self.setCentralWidget(central_widget)
-        self.setStyleSheet("QMainWindow { background-color: #1f1f1f; }")
+        # Explicitly set background and text colors to ensure readability across
+        # different OS themes
+        self.setStyleSheet(
+            "QMainWindow { background-color: #1f1f1f; color: white; }"
+        )
         self.main_layout = QVBoxLayout(central_widget)
         central_widget.setLayout(self.main_layout)
 


### PR DESCRIPTION
## Summary
- explicitly set text color in `QMainWindow` stylesheet

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py -h` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68592fc4b24c8327bc4b76112d5cd46f