### PR TITLE
Fix PyInstaller spec path

### DIFF
--- a/FOTOapp.spec
+++ b/FOTOapp.spec
@@ -1,9 +1,12 @@
 # -*- mode: python ; coding: utf-8 -*-
+import os
 
 
 a = Analysis(
     ['main.py'],
-    pathex=['C:\\Users\\vatib\\Projects\\FOTOapparatus'],
+    # Use the directory containing this spec file so the project can be built
+    # from any location
+    pathex=[os.path.dirname(os.path.abspath(__file__))],
     binaries=[],
     datas=[('assets', 'assets')],
     hiddenimports=['PySide6.QtNetwork', 'apscheduler.triggers.cron', 'apscheduler.jobstores.base', 'pygetwindow', 'win32gui', 'win32process'],


### PR DESCRIPTION
## Summary
- update `FOTOapp.spec` so that PyInstaller uses the directory of the spec
  file. This prevents missing packages like `gui` when the project lives in a
  different location.

## Testing
- `python -m py_compile FOTOapp.spec`


------
https://chatgpt.com/codex/tasks/task_e_685931978fe08327905e8b6a533ea2e1