### PR TITLE
Add configurable Discord capture mode

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -58,6 +58,11 @@ class ConfigManager:
             "target_window": "",
             "include_timestamp": True,
             "timestamp_position": "top-left",
+            "discord_settings": {
+                "stay_foreground": False,
+                "use_hotkey": False,
+                "hotkey_number": 1,
+            },
         }
 
     def load_settings(self):
@@ -69,7 +74,12 @@ class ConfigManager:
             # Biztosítjuk, hogy minden kulcs létezzen
             default_settings = self.get_default_settings()
             for key, value in default_settings.items():
-                settings.setdefault(key, value)
+                if isinstance(value, dict):
+                    settings.setdefault(key, {})
+                    for sub_key, sub_val in value.items():
+                        settings[key].setdefault(sub_key, sub_val)
+                else:
+                    settings.setdefault(key, value)
             return settings
         except (FileNotFoundError, json.JSONDecodeError, Exception) as e:
             print(f"Hiba a config betöltésekor ({self.config_path}): {e}", file=sys.stderr)

--- a/gui/discord_settings_dialog.py
+++ b/gui/discord_settings_dialog.py
@@ -1,0 +1,56 @@
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QCheckBox,
+    QSpinBox,
+    QLabel,
+    QPushButton
+)
+
+
+class DiscordSettingsDialog(QDialog):
+    """Egyszerű beállító ablak a Discord módhoz."""
+
+    def __init__(self, settings: dict | None = None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Discord mód beállításai")
+        self.setModal(True)
+
+        settings = settings or {}
+
+        layout = QVBoxLayout(self)
+
+        self.stay_foreground_cb = QCheckBox("Discord maradjon az előtérben")
+        self.stay_foreground_cb.setChecked(settings.get("stay_foreground", False))
+        layout.addWidget(self.stay_foreground_cb)
+
+        self.use_hotkey_cb = QCheckBox("Ctrl + szám lenyomása fotózás előtt")
+        self.use_hotkey_cb.setChecked(settings.get("use_hotkey", False))
+        layout.addWidget(self.use_hotkey_cb)
+
+        hotkey_layout = QHBoxLayout()
+        hotkey_layout.addWidget(QLabel("Szám:"))
+        self.hotkey_spin = QSpinBox()
+        self.hotkey_spin.setRange(0, 9)
+        self.hotkey_spin.setValue(settings.get("hotkey_number", 1))
+        hotkey_layout.addWidget(self.hotkey_spin)
+        hotkey_layout.addStretch()
+        layout.addLayout(hotkey_layout)
+
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+        ok_button = QPushButton("OK")
+        cancel_button = QPushButton("Mégse")
+        ok_button.clicked.connect(self.accept)
+        cancel_button.clicked.connect(self.reject)
+        button_layout.addWidget(ok_button)
+        button_layout.addWidget(cancel_button)
+        layout.addLayout(button_layout)
+
+    def get_settings(self) -> dict:
+        return {
+            "stay_foreground": self.stay_foreground_cb.isChecked(),
+            "use_hotkey": self.use_hotkey_cb.isChecked(),
+            "hotkey_number": self.hotkey_spin.value(),
+        }


### PR DESCRIPTION
## Summary
- Add Discord capture option with settings dialog
- Support Discord-specific screenshot workflow with optional hotkey and foreground restore
- Extend scheduler and config to handle Discord mode

## Testing
- `python -m py_compile core/config_manager.py core/screenshot_taker.py core/scheduler.py gui/discord_settings_dialog.py gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68b06e1f386083279e1159b515066e54