### PR TITLE
Persist Discord mode settings

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -433,7 +433,14 @@ class MainWindow(QMainWindow):
         if dialog.exec() == QDialog.DialogCode.Accepted:
             self.discord_settings = dialog.get_settings()
             self.settings["discord_settings"] = self.discord_settings
-            self._mark_dirty()
+            if not self.config_manager.save_settings(self.settings):
+                QMessageBox.critical(self, "Mentési Hiba", "Nem sikerült menteni a Discord beállításokat.")
+            else:
+                self.statusBar().showMessage("Discord beállítások elmentve.", 3000)
+                try:
+                    self.scheduler.reload_jobs(self.settings)
+                except Exception as e:
+                    logger.exception("Hiba scheduler újratöltésekor:")
 
     @Slot()
     def _take_test_picture(self):


### PR DESCRIPTION
## Summary
- Save Discord dialog choices directly to the configuration file
- Reload scheduler after Discord settings change

## Testing
- `python -m py_compile gui/main_window.py core/config_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0724ad9c483278483adb8805fbc3e