### PR TITLE
Require selecting Discord window for screenshots

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -62,6 +62,7 @@ class ConfigManager:
                 "stay_foreground": False,
                 "use_hotkey": False,
                 "hotkey_number": 1,
+                "window_title": "",
             },
         }
 

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -112,6 +112,9 @@ class Scheduler:
                 # Feladat hozzáadása az ütemezőhöz
                 job_id = f"capture_job_{i}"
                 if capture_type == "discord":
+                    if not discord_settings.get("window_title"):
+                        logger.warning("Discord ablak nincs kiválasztva, a feladat kihagyva.")
+                        continue
                     job_func = take_discord_screenshot
                     job_args = [
                         save_path,
@@ -121,6 +124,7 @@ class Scheduler:
                         discord_settings.get("stay_foreground", False),
                         discord_settings.get("use_hotkey", False),
                         discord_settings.get("hotkey_number", 1),
+                        discord_settings.get("window_title", "Discord"),
                     ]
                 else:
                     job_func = take_screenshot

--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -233,6 +233,7 @@ def take_discord_screenshot(
     stay_foreground: bool = False,
     use_hotkey: bool = False,
     hotkey_number: int = 1,
+    window_title: str = "Discord",
 ) -> Optional[Image.Image]:
     def pre_action():
         if use_hotkey:
@@ -240,7 +241,7 @@ def take_discord_screenshot(
             time.sleep(0.1)
 
     img = _capture_window(
-        "Discord",
+        window_title or "Discord",
         restore_foreground=not stay_foreground,
         pre_action=pre_action,
     )

--- a/gui/discord_settings_dialog.py
+++ b/gui/discord_settings_dialog.py
@@ -8,6 +8,8 @@ from PySide6.QtWidgets import (
     QPushButton
 )
 
+from .window_selector_widget import WindowSelectorWidget
+
 
 class DiscordSettingsDialog(QDialog):
     """Egyszerű beállító ablak a Discord módhoz."""
@@ -20,6 +22,10 @@ class DiscordSettingsDialog(QDialog):
         settings = settings or {}
 
         layout = QVBoxLayout(self)
+
+        self.window_selector = WindowSelectorWidget()
+        layout.addWidget(self.window_selector)
+        self.window_selector.set_selected_title(settings.get("window_title", ""))
 
         self.stay_foreground_cb = QCheckBox("Discord maradjon az előtérben")
         self.stay_foreground_cb.setChecked(settings.get("stay_foreground", False))
@@ -40,17 +46,24 @@ class DiscordSettingsDialog(QDialog):
 
         button_layout = QHBoxLayout()
         button_layout.addStretch()
-        ok_button = QPushButton("OK")
+        self.ok_button = QPushButton("OK")
         cancel_button = QPushButton("Mégse")
-        ok_button.clicked.connect(self.accept)
+        self.ok_button.clicked.connect(self.accept)
         cancel_button.clicked.connect(self.reject)
-        button_layout.addWidget(ok_button)
+        button_layout.addWidget(self.ok_button)
         button_layout.addWidget(cancel_button)
         layout.addLayout(button_layout)
+
+        self.ok_button.setEnabled(bool(self.window_selector.get_selected_title().strip()))
+        self.window_selector.selection_changed.connect(self._update_ok)
+
+    def _update_ok(self, text: str):
+        self.ok_button.setEnabled(bool(text.strip()))
 
     def get_settings(self) -> dict:
         return {
             "stay_foreground": self.stay_foreground_cb.isChecked(),
             "use_hotkey": self.use_hotkey_cb.isChecked(),
             "hotkey_number": self.hotkey_spin.value(),
+            "window_title": self.window_selector.get_selected_title(),
         }

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -461,6 +461,9 @@ class MainWindow(QMainWindow):
         img = None
         if capture_type == "discord":
             ds = self.discord_settings or {}
+            if not ds.get("window_title"):
+                QMessageBox.warning(self, "Hiányzó adat", "Válaszd ki a Discord ablakot a beállításokban.")
+                return
             img = take_discord_screenshot(
                 save_path,
                 "Teszt",
@@ -469,6 +472,7 @@ class MainWindow(QMainWindow):
                 ds.get("stay_foreground", False),
                 ds.get("use_hotkey", False),
                 ds.get("hotkey_number", 1),
+                ds.get("window_title", "Discord"),
             )
         else:
             area = None


### PR DESCRIPTION
### **User description**
## Summary
- Store Discord window title in settings
- Let users pick the Discord window and require selection before saving
- Use saved window title for Discord screenshots and scheduled jobs

## Testing
- `python -m py_compile core/config_manager.py core/screenshot_taker.py core/scheduler.py gui/discord_settings_dialog.py gui/main_window.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0731bfda8832783d6c0e59c92c01c


___

### **PR Type**
Enhancement


___

### **Description**
- Add Discord window selection requirement for screenshots

- Store selected window title in configuration settings

- Validate window selection before capturing or scheduling

- Update UI to disable actions without window selection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User opens Discord settings"] --> B["Window selector widget"]
  B --> C["Select Discord window"]
  C --> D["Store window title in config"]
  D --> E["Enable screenshot capture"]
  E --> F["Use selected window for screenshots"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_manager.py</strong><dd><code>Add window title to Discord settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/config_manager.py

- Add `window_title` field to discord_settings default configuration


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/41/files#diff-b922428b6ae5ece0d80773f599f75999b3d61747937aef52311160a3d69d6ae8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduler.py</strong><dd><code>Add window validation for scheduled Discord jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/scheduler.py

<ul><li>Add validation to skip Discord jobs without window selection<br> <li> Pass window title parameter to screenshot function</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/41/files#diff-3732d9df85981e6c160f0bccd47824125ad2f611429bb44682029e2b66e5f8cb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Support custom Discord window titles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/screenshot_taker.py

<ul><li>Add <code>window_title</code> parameter to <code>take_discord_screenshot</code> function<br> <li> Use provided window title instead of hardcoded "Discord"</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/41/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>discord_settings_dialog.py</strong><dd><code>Add Discord window selection UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/discord_settings_dialog.py

<ul><li>Add WindowSelectorWidget for choosing Discord window<br> <li> Disable OK button until window is selected<br> <li> Include window title in returned settings</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/41/files#diff-b746214ea6e63f1bf3089d1c7e7b5731e80dd1a8010cc2d49e52d2afc58e301b">+16/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main_window.py</strong><dd><code>Validate Discord window selection in main UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/main_window.py

<ul><li>Add validation warning for missing Discord window selection<br> <li> Pass window title parameter to screenshot function</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/41/files#diff-c06f3750551501fc07ce1aff486fd8b3c26780da89363df5c05d118953ee8659">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

