### PR TITLE
Fix capture mode button exclusivity

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -31,6 +31,7 @@ try:
         QStyle,
         QGroupBox,
         QRadioButton,
+        QButtonGroup,
         QDialog,
     )
     from PySide6.QtGui import QIcon, QAction
@@ -336,6 +337,11 @@ class MainWindow(QMainWindow):
         discord_row_layout.addWidget(self.btn_discord_settings)
         discord_row_layout.addStretch()
         capture_layout.addWidget(discord_row_widget)
+        self.capture_mode_group = QButtonGroup(self.capture_group)
+        self.capture_mode_group.setExclusive(True)
+        self.capture_mode_group.addButton(self.radio_capture_screenshot)
+        self.capture_mode_group.addButton(self.radio_capture_program)
+        self.capture_mode_group.addButton(self.radio_capture_discord)
         self.radio_capture_screenshot.setChecked(True)
         self.btn_discord_settings.setEnabled(False)
         self.main_layout.addWidget(self.capture_group)


### PR DESCRIPTION
### **User description**
## Summary
- group capture mode radio buttons using QButtonGroup so only one mode can be active at a time

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0743ce97c832784cf5726fe19e222


___

### **PR Type**
Bug fix


___

### **Description**
- Add QButtonGroup to ensure exclusive capture mode selection

- Fix radio button behavior for screenshot, program, and Discord modes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Radio Buttons"] --> B["QButtonGroup"] --> C["Exclusive Selection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main_window.py</strong><dd><code>Add QButtonGroup for exclusive radio button selection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/main_window.py

<ul><li>Import QButtonGroup from PySide6.QtWidgets<br> <li> Create capture_mode_group with exclusive selection enabled<br> <li> Add all three radio buttons to the button group<br> <li> Ensure only one capture mode can be active at a time</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/42/files#diff-c06f3750551501fc07ce1aff486fd8b3c26780da89363df5c05d118953ee8659">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

