### PR TITLE
Improve Discord window selection handling

### DIFF
--- a/gui/window_selector_widget.py
+++ b/gui/window_selector_widget.py
@@ -13,13 +13,15 @@ from PySide6.QtCore import Signal
 
 import platform
 
-try:
-    if platform.system() == "Windows":
-        import pygetwindow as gw
-    else:
-        gw = None
-except Exception:
-    gw = None
+_import_error = False
+gw = None
+
+if platform.system() == "Windows":
+    try:
+        import pygetwindow as gw  # type: ignore
+    except Exception:
+        _import_error = True
+
 
 class WindowSelectorWidget(QWidget):
     """Widget a futó alkalmazások ablakainak kiválasztásához."""
@@ -38,7 +40,11 @@ class WindowSelectorWidget(QWidget):
         group_layout = QVBoxLayout(group_box)
 
         if gw is None:
-            self.info_label = QLabel("Nem támogatott rendszer")
+            if _import_error:
+                message = "Hiányzik a pygetwindow modul"
+            else:
+                message = "Nem támogatott rendszer"
+            self.info_label = QLabel(message)
             group_layout.addWidget(self.info_label)
             self.combo = None
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ APScheduler
 Pillow
 opencv-python
 pywin32; platform_system == 'Windows'
+pygetwindow; platform_system == 'Windows'


### PR DESCRIPTION
## Summary
- list missing Discord windows by depending on `pygetwindow`
- show a specific message when the `pygetwindow` module is unavailable

## Testing
- `python -m pytest`
- `python -m py_compile gui/window_selector_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0755bcb8c832783b33410f186e436