### PR TITLE
Add delay for Discord hotkey before screenshot

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -144,6 +144,8 @@ def _press_ctrl_number(number: int) -> None:
     vk_code = ord(str(number))
     win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)
     win32api.keybd_event(vk_code, 0, 0, 0)
+    # hagyjunk egy kis időt, hogy a rendszer érzékelje a kombinációt
+    time.sleep(0.05)
     win32api.keybd_event(vk_code, 0, win32con.KEYEVENTF_KEYUP, 0)
     win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
 
@@ -238,7 +240,8 @@ def take_discord_screenshot(
     def pre_action():
         if use_hotkey:
             _press_ctrl_number(hotkey_number)
-            time.sleep(0.1)
+            # biztosítsunk elegendő időt a váltásra
+            time.sleep(0.5)
 
     img = _capture_window(
         window_title or "Discord",


### PR DESCRIPTION
## Summary
- ensure Ctrl+number combo is held briefly before taking a Discord screenshot
- wait longer after sending the hotkey so Discord can switch channels

## Testing
- `python -m py_compile core/screenshot_taker.py`

------
https://chatgpt.com/codex/tasks/task_e_68b07809ea0c8327a27740ed53f41802