### PR TITLE
Ensure Discord screenshot sends hotkey before capture

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -237,16 +237,14 @@ def take_discord_screenshot(
     hotkey_number: int = 1,
     window_title: str = "Discord",
 ) -> Optional[Image.Image]:
-    def pre_action():
-        if use_hotkey:
-            _press_ctrl_number(hotkey_number)
-            # biztosítsunk elegendő időt a váltásra
-            time.sleep(0.5)
+    if use_hotkey:
+        _press_ctrl_number(hotkey_number)
+        # biztosítsunk elegendő időt a váltásra
+        time.sleep(0.5)
 
     img = _capture_window(
         window_title or "Discord",
         restore_foreground=not stay_foreground,
-        pre_action=pre_action,
     )
     if img is None:
         return None


### PR DESCRIPTION
### **User description**
## Summary
- Correct Discord capture order so optional hotkey is sent before capturing

## Testing
- `python -m py_compile core/screenshot_taker.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b07985084083279c06597817792400


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Discord screenshot hotkey timing issue

- Move hotkey press before window capture

- Remove unnecessary pre_action function wrapper


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hotkey Press"] --> B["Window Capture"] --> C["Screenshot Taken"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Reorder hotkey execution before window capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/screenshot_taker.py

<ul><li>Move hotkey press logic outside of pre_action function<br> <li> Execute hotkey before window capture instead of during<br> <li> Remove pre_action parameter from _capture_window call<br> <li> Maintain 0.5 second delay after hotkey press</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/47/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

