### PR TITLE
Fix Discord mode hotkey order

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -264,16 +264,14 @@ def take_discord_screenshot(
     hotkey_number: int = 1,
     window_title: str = "Discord",
 ) -> Optional[Image.Image]:
-    def pre_action():
-        if use_hotkey:
-            _press_ctrl_number(hotkey_number)
-            # biztosítsunk elegendő időt a váltásra
-            time.sleep(0.5)
+    if use_hotkey:
+        _press_ctrl_number(hotkey_number)
+        # biztosítsunk elegendő időt a váltásra
+        time.sleep(0.5)
 
     img = _capture_window(
         window_title or "Discord",
         restore_foreground=not stay_foreground,
-        pre_action=pre_action,
         executable="discord.exe",
     )
     if img is None:


### PR DESCRIPTION
### **User description**
## Summary
- ensure Discord mode presses the configured hotkey before taking a screenshot

## Testing
- `python -m py_compile core/screenshot_taker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b07ae48cc08327913c158ee458e854


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Discord mode hotkey execution order

- Move hotkey press before window capture

- Remove pre_action callback mechanism


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Discord Screenshot"] --> B["Press Hotkey"]
  B --> C["Wait 0.5s"]
  C --> D["Capture Window"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Reorder hotkey execution in Discord screenshot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/screenshot_taker.py

<ul><li>Move hotkey press logic from pre_action callback to main function flow<br> <li> Execute hotkey before window capture instead of during capture<br> <li> Remove pre_action parameter from _capture_window call</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/48/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

