### PR TITLE
Preserve Discord fullscreen during capture

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -79,7 +79,11 @@ def _capture_window(
 
     img = None
     try:
-        win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
+        # Only restore the window if it is minimized. Calling SW_RESTORE on a
+        # fullscreen/ maximized window would shrink it to windowed mode, which
+        # is undesirable when capturing programs like Discord.
+        if win32gui.IsIconic(hwnd):
+            win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
         win32gui.SetForegroundWindow(hwnd)
 
         # Ensure the window really moves to the foreground before capturing


### PR DESCRIPTION
### **User description**
## Summary
- Avoid shrinking fullscreen Discord to windowed when capturing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b07b4b01d48327989a87ebdb854978


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve Discord fullscreen mode during window capture

- Only restore minimized windows, avoid shrinking fullscreen/maximized windows

- Add conditional check using `IsIconic()` before window restoration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Window Capture"] --> B["Check if Minimized"]
  B --> C["IsIconic() Check"]
  C -->|Yes| D["Restore Window"]
  C -->|No| E["Skip Restoration"]
  D --> F["Set Foreground"]
  E --> F["Set Foreground"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Conditional window restoration for fullscreen preservation</code></dd></summary>
<hr>

core/screenshot_taker.py

<ul><li>Add conditional check using <code>win32gui.IsIconic()</code> before window <br>restoration<br> <li> Only restore minimized windows to avoid shrinking fullscreen/maximized <br>windows<br> <li> Add explanatory comment about Discord fullscreen preservation</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/49/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

