### PR TITLE
Add delay for Discord hotkey recognition

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -174,10 +174,12 @@ def _press_ctrl_number(number: int) -> None:
     number = max(0, min(9, int(number)))
     vk_code = ord(str(number))
     win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)
+    time.sleep(0.05)
     win32api.keybd_event(vk_code, 0, 0, 0)
     # hagyjunk egy kis időt, hogy a rendszer érzékelje a kombinációt
-    time.sleep(0.05)
+    time.sleep(0.1)
     win32api.keybd_event(vk_code, 0, win32con.KEYEVENTF_KEYUP, 0)
+    time.sleep(0.05)
     win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
 
 


### PR DESCRIPTION
### **User description**
## Summary
- add short pauses around Ctrl+number hotkey to ensure Discord registers the combination

## Testing
- `python -m py_compile core/screenshot_taker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b07f6e010c8327bf0cd3ad0bce31e0


___

### **PR Type**
Bug fix


___

### **Description**
- Add timing delays around Discord Ctrl+number hotkey

- Improve hotkey recognition reliability in Windows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Press Ctrl"] --> B["Delay 0.05s"] --> C["Press Number"] --> D["Delay 0.1s"] --> E["Release Number"] --> F["Delay 0.05s"] --> G["Release Ctrl"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Enhanced Discord hotkey timing delays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/screenshot_taker.py

<ul><li>Add 0.05s delay after pressing Ctrl key<br> <li> Increase middle delay from 0.05s to 0.1s<br> <li> Add 0.05s delay before releasing Ctrl key</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/51/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

