### PR TITLE
feat: add configurable Discord screenshot delay

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -297,6 +297,7 @@ def take_discord_screenshot(
     use_hotkey: bool = False,
     hotkey_number: int = 1,
     window_title: str = "Discord",
+    delay_after_hotkey: float = 5.0,
 ) -> Optional[Image.Image]:
     """Capture a screenshot of the Discord window.
 
@@ -318,7 +319,8 @@ def take_discord_screenshot(
             # Discord a brief period to react to the shortcut before the
             # screenshot is taken.
             _press_ctrl_number(hotkey_number)
-            time.sleep(2)
+            print(f"Waiting {delay_after_hotkey} seconds for Discord UI to update...")
+            time.sleep(delay_after_hotkey)
 
     img = _capture_window(
         window_title or "Discord",

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -470,6 +470,7 @@ class MainWindow(QMainWindow):
             if not ds.get("window_title"):
                 QMessageBox.warning(self, "Hiányzó adat", "Válaszd ki a Discord ablakot a beállításokban.")
                 return
+            self.statusBar().showMessage("Discord test... Screenshot will be taken in 10 seconds.", 10000)
             img = take_discord_screenshot(
                 save_path,
                 "Teszt",
@@ -479,6 +480,7 @@ class MainWindow(QMainWindow):
                 ds.get("use_hotkey", False),
                 ds.get("hotkey_number", 1),
                 ds.get("window_title", "Discord"),
+                10.0,
             )
         else:
             area = None


### PR DESCRIPTION
### **User description**
## Summary
- add configurable `delay_after_hotkey` parameter for Discord screenshots
- show delay notice and use 10s pause when testing Discord capture

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6ca7dd36483279aa549b4490a661c


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable delay parameter for Discord screenshots

- Replace hardcoded 2-second delay with customizable timing

- Show status message during Discord test captures

- Set 10-second delay for testing Discord functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Discord Screenshot Function"] --> B["Configurable delay_after_hotkey"]
  B --> C["User feedback during test"]
  C --> D["Improved screenshot timing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Add configurable delay parameter to Discord capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/screenshot_taker.py

<ul><li>Add <code>delay_after_hotkey</code> parameter with 5.0s default<br> <li> Replace hardcoded 2-second sleep with configurable delay<br> <li> Add informative print message showing wait time</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/57/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main_window.py</strong><dd><code>Enhance Discord test with status message and delay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/main_window.py

<ul><li>Add status bar message for Discord test screenshots<br> <li> Pass 10-second delay for Discord test captures<br> <li> Improve user feedback during testing process</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/57/files#diff-c06f3750551501fc07ce1aff486fd8b3c26780da89363df5c05d118953ee8659">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

