### PR TITLE
Improve Discord hotkey reliability and timing

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -470,7 +470,7 @@ class MainWindow(QMainWindow):
             if not ds.get("window_title"):
                 QMessageBox.warning(self, "Hiányzó adat", "Válaszd ki a Discord ablakot a beállításokban.")
                 return
-            self.statusBar().showMessage("Discord test... Screenshot will be taken in 10 seconds.", 10000)
+            self.statusBar().showMessage("Discord test... Screenshot will be taken in 3 seconds.", 3000)
             img = take_discord_screenshot(
                 save_path,
                 "Teszt",
@@ -480,7 +480,7 @@ class MainWindow(QMainWindow):
                 ds.get("use_hotkey", False),
                 ds.get("hotkey_number", 1),
                 ds.get("window_title", "Discord"),
-                10.0,
+                3.0,
             )
         else:
             area = None


### PR DESCRIPTION
## Summary
- Replace unreliable `keybd_event` usage with low-level `SendInput` for Ctrl+number hotkey
- Default Discord capture delay shortened to 2s, test mode uses 3s delay

## Testing
- `python -m py_compile core/screenshot_taker.py gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6cf7523b483279fdd7fb9c7430495