### PR TITLE
fix: support python 3.12 missing wintypes ULONG_PTR

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -19,7 +19,10 @@ if platform.system() == "Windows":
     import win32api
 
     # -- Canonical ctypes definitions for SendInput structures --
-    ULONG_PTR = wintypes.ULONG_PTR
+    # ``ctypes.wintypes`` may not expose ``ULONG_PTR`` on some Python versions
+    # (e.g. Python 3.12).  Falling back to ``ctypes.c_size_t`` ensures the
+    # structure uses an unsigned integer with the native pointer size.
+    ULONG_PTR = getattr(wintypes, "ULONG_PTR", ctypes.c_size_t)
 
     class MOUSEINPUT(ctypes.Structure):
         _fields_ = [


### PR DESCRIPTION
## Summary
- handle absence of `ctypes.wintypes.ULONG_PTR` by falling back to `ctypes.c_size_t`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6d2d3a8c4832791a0757ea33f1b4c