### PR TITLE
Ensure CTRL extended flag for accurate SendInput hotkeys

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -226,6 +226,7 @@ def _press_ctrl_number(number: int) -> None:
     INPUT_KEYBOARD = 1
     KEYEVENTF_KEYUP = 0x0002
     KEYEVENTF_SCANCODE = 0x0008
+    KEYEVENTF_EXTENDEDKEY = 0x0001
 
     # Map virtual keys to hardware scan codes
     ctrl_scan = win32api.MapVirtualKey(win32con.VK_LCONTROL, 0)
@@ -238,7 +239,7 @@ def _press_ctrl_number(number: int) -> None:
     inputs[0].ki = KEYBDINPUT(
         wVk=0,
         wScan=ctrl_scan,
-        dwFlags=KEYEVENTF_SCANCODE,
+        dwFlags=KEYEVENTF_SCANCODE | KEYEVENTF_EXTENDEDKEY,
         time=0,
         dwExtraInfo=0,
     )
@@ -268,7 +269,7 @@ def _press_ctrl_number(number: int) -> None:
     inputs[3].ki = KEYBDINPUT(
         wVk=0,
         wScan=ctrl_scan,
-        dwFlags=KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP,
+        dwFlags=KEYEVENTF_SCANCODE | KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP,
         time=0,
         dwExtraInfo=0,
     )


### PR DESCRIPTION
### **User description**
## Summary
- Add KEYEVENTF_EXTENDEDKEY constant and apply it to CTRL key events in SendInput
- Keep number key events unchanged while still sending all inputs at once

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6d59dfde883278dafe068b9525649


___

### **PR Type**
Bug fix


___

### **Description**
- Add `KEYEVENTF_EXTENDEDKEY` flag to CTRL key events in SendInput

- Fix Windows hotkey simulation for accurate CTRL+number combinations

- Maintain existing number key handling without extended flag


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CTRL key events"] -- "add KEYEVENTF_EXTENDEDKEY flag" --> B["Enhanced SendInput"]
  B -- "accurate simulation" --> C["CTRL+number hotkeys"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Add extended key flag for CTRL events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/screenshot_taker.py

<ul><li>Add <code>KEYEVENTF_EXTENDEDKEY</code> constant definition<br> <li> Apply extended key flag to CTRL down event<br> <li> Apply extended key flag to CTRL up event<br> <li> Keep number key events unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/62/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

