### PR TITLE
Increase Discord screenshot delay to 10 seconds

### DIFF
--- a/core/screenshot_taker.py
+++ b/core/screenshot_taker.py
@@ -260,7 +260,7 @@ def take_discord_screenshot(
     use_hotkey: bool = False,
     hotkey_number: int = 1,
     window_title: str = "Discord",
-    delay_after_hotkey: float = 2.0,
+    delay_after_hotkey: float = 10.0,
 ) -> Optional[Image.Image]:
     pre_action = None
     if use_hotkey:

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -470,7 +470,7 @@ class MainWindow(QMainWindow):
             if not ds.get("window_title"):
                 QMessageBox.warning(self, "Hiányzó adat", "Válaszd ki a Discord ablakot a beállításokban.")
                 return
-            self.statusBar().showMessage("Discord test... Screenshot will be taken in 3 seconds.", 3000)
+            self.statusBar().showMessage("Discord test... Screenshot will be taken in 10 seconds.", 10000)
             img = take_discord_screenshot(
                 save_path,
                 "Teszt",
@@ -480,7 +480,7 @@ class MainWindow(QMainWindow):
                 ds.get("use_hotkey", False),
                 ds.get("hotkey_number", 1),
                 ds.get("window_title", "Discord"),
-                3.0,
+                10.0,
             )
         else:
             area = None


### PR DESCRIPTION
## Summary
- Standardize Discord hotkey delay to 10 seconds for reliable screenshots
- Update GUI test trigger to wait 10 seconds and show matching status message

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6db03e1188327b7d7534de24ebf74