### PR TITLE
Allow custom area in Discord mode

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -119,6 +119,7 @@ class Scheduler:
                     job_args = [
                         save_path,
                         "Kép",
+                        area_arg,
                         include_timestamp,
                         timestamp_position,
                         discord_settings.get("stay_foreground", False),

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -422,7 +422,7 @@ class MainWindow(QMainWindow):
             capture_type = "program"
         else:
             capture_type = "screenshot"
-        size_enabled = capture_type == "screenshot"
+        size_enabled = capture_type in ("screenshot", "discord")
         window_enabled = capture_type == "program"
         self.size_widget.setEnabled(size_enabled)
         self.window_selector.setEnabled(window_enabled)
@@ -476,6 +476,13 @@ class MainWindow(QMainWindow):
                 self.test_button.setEnabled(True)
                 return
 
+            area = None
+            mode = self.size_widget.get_mode()
+            if mode == "custom":
+                rect = self.size_widget.get_custom_rect()
+                if rect.isValid():
+                    area = rect
+
             self.statusBar().showMessage(
                 "Discord teszt folyamatban... A kép kb. 10 másodperc múlva készül."
             )
@@ -483,6 +490,7 @@ class MainWindow(QMainWindow):
                 take_discord_screenshot(
                     save_path,
                     "Teszt",
+                    area,
                     add_timestamp=include_timestamp,
                     timestamp_position=timestamp_position,
                     stay_foreground=True,
@@ -496,7 +504,7 @@ class MainWindow(QMainWindow):
                 self.test_button.setEnabled(True)
                 return
 
-            self._final_capture_params = (save_path, include_timestamp, timestamp_position)
+            self._final_capture_params = (save_path, area, include_timestamp, timestamp_position)
             QTimer.singleShot(7500, self._trigger_final_capture)
             return
 
@@ -530,13 +538,13 @@ class MainWindow(QMainWindow):
         if not params:
             self.test_button.setEnabled(True)
             return
-        save_path, include_timestamp, timestamp_position = params
+        save_path, area, include_timestamp, timestamp_position = params
         self._final_capture_params = None
         try:
             img = take_screenshot(
                 save_path,
                 "Teszt",
-                None,
+                area,
                 include_timestamp,
                 timestamp_position,
                 "",


### PR DESCRIPTION
### **User description**
## Summary
- enable selecting custom capture area when using Discord capture mode
- crop and save Discord screenshots using the chosen area
- schedule Discord jobs with optional custom region

## Testing
- `python -m py_compile core/screenshot_taker.py gui/main_window.py core/scheduler.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7565abc8c8327b1710992ef720e3e


___

### **PR Type**
Enhancement


___

### **Description**
- Enable custom area selection for Discord capture mode

- Add area parameter to Discord screenshot functions

- Integrate custom region cropping with Discord workflow

- Update GUI to allow size selection for Discord mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GUI["GUI Size Widget"] -- "custom area" --> Discord["Discord Screenshot"]
  Discord -- "crop region" --> Capture["Screen Capture"]
  Scheduler["Scheduler"] -- "area parameter" --> Discord
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>screenshot_taker.py</strong><dd><code>Add custom area support to Discord screenshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/screenshot_taker.py

<ul><li>Add optional <code>area</code> parameter to <code>take_discord_screenshot</code> function<br> <li> Implement custom region cropping logic for Discord screenshots<br> <li> Handle window restoration when using custom areas<br> <li> Support both QRect and tuple area formats</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/71/files#diff-5174fcc84b2192b0ceb4bef77dd5773d084d44855015f002e963f2a3ed4773e5">+32/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main_window.py</strong><dd><code>Enable GUI size selection for Discord mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/main_window.py

<ul><li>Enable size widget for Discord capture mode<br> <li> Pass custom area to Discord screenshot functions<br> <li> Update test capture to include area parameter<br> <li> Modify final capture parameters to include area</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/71/files#diff-c06f3750551501fc07ce1aff486fd8b3c26780da89363df5c05d118953ee8659">+12/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scheduler.py</strong><dd><code>Add area parameter to Discord job scheduling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/scheduler.py

<ul><li>Add <code>area_arg</code> parameter to Discord job scheduling<br> <li> Pass area parameter to <code>take_discord_screenshot</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/71/files#diff-3732d9df85981e6c160f0bccd47824125ad2f611429bb44682029e2b66e5f8cb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

