### PR TITLE
Ensure Discord captures run on Qt main thread

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -20,8 +20,9 @@ except ImportError:
     # Ha önállóan futtatjuk teszteléshez
     from screenshot_taker import take_screenshot
 
-# PySide6 import a QRect-hez (ha a terület konverziót itt végezzük)
-from PySide6.QtCore import QRect, QTimer
+# PySide6 importok a QRect-hez és a főszálon történő híváshoz
+from PySide6.QtCore import QRect, QMetaObject, Qt
+from PySide6.QtWidgets import QApplication
 
 # Logging beállítása
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -61,12 +62,13 @@ class Scheduler:
 
         APScheduler futtatja a feladatokat háttérszálon, ami néha
         akadályozhatja a fókuszváltást, ha az alkalmazás tálcára van
-        minimalizálva. A ``QTimer.singleShot`` segítségével a képkészítés
-        a Qt fő szálára kerül, így megegyezik a teszt gomb viselkedésével.
+        minimalizálva. A ``QMetaObject.invokeMethod`` segítségével a
+        képkészítés a Qt fő szálára kerül, így megegyezik a teszt gomb
+        viselkedésével.
         """
 
-        QTimer.singleShot(
-            0,
+        QMetaObject.invokeMethod(
+            QApplication.instance(),
             lambda: take_discord_screenshot(
                 save_path,
                 filename_prefix,
@@ -79,6 +81,7 @@ class Scheduler:
                 window_title,
                 delay_after_hotkey,
             ),
+            Qt.QueuedConnection,
         )
 
     def _schedule_jobs(self):


### PR DESCRIPTION
### **User description**
## Summary
- Dispatch Discord capture jobs via `QMetaObject.invokeMethod` to ensure they run on the Qt main thread
- Import Qt classes needed for queued invocation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7f572d6248327a834824decf07ac3


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `QTimer.singleShot` with `QMetaObject.invokeMethod` for Discord captures

- Add `Qt.QueuedConnection` parameter for proper thread queuing

- Import additional Qt classes for main thread execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["APScheduler Background Thread"] -- "invoke" --> B["QMetaObject.invokeMethod"]
  B -- "Qt.QueuedConnection" --> C["Qt Main Thread"]
  C --> D["take_discord_screenshot"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduler.py</strong><dd><code>Fix Discord capture thread execution method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/scheduler.py

<ul><li>Replace <code>QTimer.singleShot</code> with <code>QMetaObject.invokeMethod</code> for Discord <br>captures<br> <li> Add <code>QMetaObject</code>, <code>Qt</code>, and <code>QApplication</code> imports<br> <li> Use <code>Qt.QueuedConnection</code> parameter for proper thread queuing<br> <li> Update comments to reflect the new threading approach</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/74/files#diff-3732d9df85981e6c160f0bccd47824125ad2f611429bb44682029e2b66e5f8cb">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

