### PR TITLE
Refactor Discord screenshot flow and scheduler thread handling

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -21,8 +21,7 @@ except ImportError:
     from screenshot_taker import take_screenshot
 
 # PySide6 importok a QRect-hez és a főszálon történő híváshoz
-from PySide6.QtCore import QRect, QMetaObject, Qt
-from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QRect, QTimer
 
 # Logging beállítása
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -58,17 +57,10 @@ class Scheduler:
         window_title,
         delay_after_hotkey,
     ):
-        """Invoke Discord screenshot capture on the Qt main thread.
+        """Delegate Discord capture to the Qt main thread using QTimer."""
 
-        APScheduler futtatja a feladatokat háttérszálon, ami néha
-        akadályozhatja a fókuszváltást, ha az alkalmazás tálcára van
-        minimalizálva. A ``QMetaObject.invokeMethod`` segítségével a
-        képkészítés a Qt fő szálára kerül, így megegyezik a teszt gomb
-        viselkedésével.
-        """
-
-        QMetaObject.invokeMethod(
-            QApplication.instance(),
+        QTimer.singleShot(
+            0,
             lambda: take_discord_screenshot(
                 save_path,
                 filename_prefix,
@@ -81,7 +73,6 @@ class Scheduler:
                 window_title,
                 delay_after_hotkey,
             ),
-            Qt.QueuedConnection,
         )
 
     def _schedule_jobs(self):


### PR DESCRIPTION
## Summary
- consolidate Discord screenshot workflow into a single function
- simplify test button to call unified screenshot taker
- schedule Discord captures on GUI thread via QTimer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b84c6f6a748327acdad043217586f4