### PR TITLE
Expand GUI height to show more schedule dates

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -104,9 +104,9 @@ class MainWindow(QMainWindow):
         # A kicsit szélesebb alapméret biztosítja, hogy
         # az "Indítás a Windows-zal" felirat ne törjön meg.
         base_width = 600
-        base_height = 500 + 70  # extend height by 70 pixels
+        base_height = 570  # increased by 70px to show more schedule dates
         self.resize(base_width, base_height)
-        self.setMinimumWidth(base_width)
+        self.setMinimumSize(base_width, base_height)
         self._current_width = base_width
 
         self.config_manager = ConfigManager()


### PR DESCRIPTION
## Summary
- Increase main window default height by 70px for better schedule visibility
- Enforce minimum window size to match new dimensions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b855291318832782e3fdab7e6afae1