### PR TITLE
Fix PyInstaller spec path resolution

### DIFF
--- a/FOTOapp.spec
+++ b/FOTOapp.spec
@@ -2,11 +2,18 @@
 import os
 
 
+# ``__file__`` is not defined when PyInstaller executes the spec file.  However,
+# the absolute path to the spec file is provided via the ``SPEC`` global
+# variable.  Using ``SPEC`` keeps the configuration portable while avoiding a
+# ``NameError`` when the spec is evaluated.
+spec_root = os.path.dirname(SPEC)
+
+
 a = Analysis(
     ['main.py'],
     # Use the directory containing this spec file so the project can be built
     # from any location
-    pathex=[os.path.dirname(os.path.abspath(__file__))],
+    pathex=[spec_root],
     binaries=[],
     datas=[('assets', 'assets')],
     hiddenimports=['PySide6.QtNetwork', 'apscheduler.triggers.cron', 'apscheduler.jobstores.base', 'pygetwindow', 'win32gui', 'win32process'],


### PR DESCRIPTION
### **User description**
## Summary
- ensure the PyInstaller spec uses the provided SPEC path instead of __file__ so builds work when the spec is exec'd

## Testing
- python build_exe.py --clear-output

------
https://chatgpt.com/codex/tasks/task_e_68cfe4b2c9808327951ff76a459a57cb


___

### **PR Type**
Bug fix


___

### **Description**
- Fix PyInstaller spec path resolution using `SPEC` variable

- Replace `__file__` reference to prevent NameError during build

- Add detailed comments explaining the fix rationale


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["__file__ reference"] -- "causes NameError" --> B["Build failure"]
  C["SPEC variable"] -- "replaces __file__" --> D["Successful build"]
  A -- "fixed by" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FOTOapp.spec</strong><dd><code>Fix path resolution using SPEC variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

FOTOapp.spec

<ul><li>Replace <code>__file__</code> with <code>SPEC</code> variable for path resolution<br> <li> Add comprehensive comments explaining the fix<br> <li> Define <code>spec_root</code> variable for cleaner code organization</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/FOTOapparatus/pull/82/files#diff-bd1bd04c5a99968376da85b1ce3ed91c064d442eb7ee2b8b17127b44f93308ef">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

